### PR TITLE
[refactor/#8] signup 비동기 적용

### DIFF
--- a/feature/login/src/main/java/com/boostcamp/mapisode/login/AuthViewModel.kt
+++ b/feature/login/src/main/java/com/boostcamp/mapisode/login/AuthViewModel.kt
@@ -10,6 +10,7 @@ import com.boostcamp.mapisode.mygroup.GroupRepository
 import com.boostcamp.mapisode.ui.base.BaseViewModel
 import com.boostcamp.mapisode.user.UserRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.launch
 import java.util.Date
@@ -21,6 +22,7 @@ class AuthViewModel @Inject constructor(
 	private val groupRepository: GroupRepository,
 	private val userDataStore: UserPreferenceDataStore,
 ) : BaseViewModel<AuthIntent, AuthState, AuthSideEffect>(AuthState()) {
+	private var startTime: Long = 0L
 
 	override fun onIntent(intent: AuthIntent) {
 		when (intent) {
@@ -130,6 +132,7 @@ class AuthViewModel @Inject constructor(
 	}
 
 	private fun handleSignUp() {
+		startTime = System.currentTimeMillis()
 		intent {
 			copy(isLoading = true)
 		}
@@ -141,8 +144,11 @@ class AuthViewModel @Inject constructor(
 				if (currentState.authData == null) throw IllegalArgumentException("로그인 정보가 없습니다.")
 
 				val localUri = currentState.profileUrl
-				val storageUrl = getStorageUrl()
-				onProfileUrlChange(storageUrl)
+				launch(Dispatchers.IO) {
+					val storageUrl = getStorageUrl()
+					onProfileUrlChange(storageUrl)
+					updateDataStoreProfileUrl(storageUrl)
+				}
 
 				val user = UserModel(
 					uid = currentState.authData?.uid
@@ -155,20 +161,28 @@ class AuthViewModel @Inject constructor(
 					groups = emptyList(),
 				)
 
-				userRepository.createUser(user)
-				createMyEpisodeGroup(
-					user.copy(
-						profileUrl = localUri,
-					),
-				)
+				launch(Dispatchers.IO) {
+					userRepository.createUser(user)
+				}
 
-				storeUserData(
-					userModel = user,
-					credentialId = currentState.authData?.idToken ?: throw IllegalArgumentException(
-						"로그인 정보가 없습니다.",
-					),
-					recentGroup = user.uid,
-				)
+				launch(Dispatchers.IO) {
+					createMyEpisodeGroup(
+						user.copy(
+							profileUrl = localUri,
+						),
+					)
+				}
+
+				launch(Dispatchers.IO) {
+					storeUserData(
+						userModel = user,
+						credentialId = currentState.authData?.idToken
+							?: throw IllegalArgumentException(
+								"로그인 정보가 없습니다.",
+							),
+						recentGroup = user.uid,
+					)
+				}
 
 				onIntent(AuthIntent.OnLoginSuccess)
 			} catch (e: Exception) {
@@ -177,16 +191,16 @@ class AuthViewModel @Inject constructor(
 		}
 	}
 
+	private suspend fun updateDataStoreProfileUrl(profileUrl: String) {
+		userDataStore.updateProfileUrl(profileUrl)
+	}
+
 	private suspend fun getStorageUrl(): String {
-		try {
-			return userRepository.uploadProfileImageToStorage(
-				imageUri = currentState.profileUrl,
-				uid = currentState.authData?.uid
-					?: throw IllegalArgumentException("UID cannot be empty"),
-			)
-		} catch (e: Exception) {
-			throw e
-		}
+		return userRepository.uploadProfileImageToStorage(
+			imageUri = currentState.profileUrl,
+			uid = currentState.authData?.uid
+				?: throw IllegalArgumentException("UID cannot be empty"),
+		)
 	}
 
 	private suspend fun getUserInfo(uid: String): UserModel = try {
@@ -195,37 +209,32 @@ class AuthViewModel @Inject constructor(
 		throw Exception("Failed to get user", e)
 	}
 
-	private fun storeUserData(
+	private suspend fun storeUserData(
 		userModel: UserModel,
 		credentialId: String,
 		recentGroup: String,
 	) {
-		viewModelScope.launch {
-			with(userDataStore) {
-				updateUserId(userModel.uid)
-				updateUsername(userModel.name)
-				updateProfileUrl(userModel.profileUrl)
-				updateIsFirstLaunch()
-				updateCredentialIdToken(credentialId)
-				updateRecentSelectedGroup(recentGroup)
-			}
+		with(userDataStore) {
+			updateUserId(userModel.uid)
+			updateUsername(userModel.name)
+			updateIsFirstLaunch()
+			updateCredentialIdToken(credentialId)
+			updateRecentSelectedGroup(recentGroup)
 		}
 	}
 
 	private suspend fun createMyEpisodeGroup(user: UserModel) {
-		viewModelScope.launch {
-			groupRepository.createGroup(
-				GroupModel(
-					id = user.uid,
-					adminUser = user.uid,
-					createdAt = Date.from(java.time.Instant.now()),
-					description = "내가 작성한 에피소드",
-					imageUrl = user.profileUrl,
-					name = "\uD83D\uDC51 나만의 에피소드",
-					members = listOf(user.uid),
-				),
-			)
-		}.join()
+		groupRepository.createGroup(
+			GroupModel(
+				id = user.uid,
+				adminUser = user.uid,
+				createdAt = Date.from(java.time.Instant.now()),
+				description = "내가 작성한 에피소드",
+				imageUrl = user.profileUrl,
+				name = "\uD83D\uDC51 나만의 에피소드",
+				members = listOf(user.uid),
+			),
+		)
 	}
 
 	private fun handleLoginSuccess() {


### PR DESCRIPTION
- closed #8 

## *📍 Work Description*

- 비동기 적용
- Optimistic한 방식으로 비동기 동작
  - 지도 진입 시간 7800ms -> 2ms
  - 다른 화면에서 네트워크로 데이터를 가져오는 것이 아닌 DataStore에서 flow로 가져오기 때문에 Optimistic한 방식으로 동작해도 문제가 없음.

## *📸 Screenshot*
< 이전 동작 시간 >
<img src="https://github.com/user-attachments/assets/8aec5904-c982-4967-b46b-b3da5c04da71" width=270 />

< 리팩토링 이후 >
<img src="https://github.com/user-attachments/assets/32242e5e-f8dc-48ae-a424-969986789239" width=270 />

<!-- 실행 사진이나 영상을 드래그하여 첨부해주세요. -->
<!-- <img src="이미지 주소" width=270 /> -->



## ⏲️Time

    - 1 h 
